### PR TITLE
Unification of the project structure of vsix 'Soneta Addon' with dotnet new

### DIFF
--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddon.vstemplate
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddon.vstemplate
@@ -21,4 +21,8 @@
       <ProjectTemplateLink ProjectName="$safeprojectname$.Tests">SonetaAddonProject\SonetaAddon.Tests.vstemplate</ProjectTemplateLink>
     </ProjectCollection>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>ItemTemplateWizard, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null</Assembly>
+    <FullClassName>ItemTemplateWizard.Wizards.SonetaAddonProjectTemplateWizard</FullClassName>
+  </WizardExtension>
 </VSTemplate>


### PR DESCRIPTION
Odzwierciedlenie zachowania "Soneta Addon" w dotnet new, by szablon vsix zachowywał się analogicznie:

**W dotnet new zdefiniowano operator -n by nadać nazwę projektu ~ w vsix odznaczono opcję "Place solution and project in the same directory".**

W podanej lokalizacji tworzony jest nowy folder o podanej przez użytkownika nazwie projetku, a w nim zawarte są luzem pliki konfiguracyjne i solucja (w przypadku vsix). Każdy plik projektu ma swój folder o tej samej nazwie co projekt.