### PR TITLE
Komunikat o konieczności wcześniejszego dodania szablonu konfiguracji, przed dodaniem właściwego szablonu projektu

### DIFF
--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/SonetaAddon.Project.vstemplate
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/SonetaAddon.Project.vstemplate
@@ -1,7 +1,7 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
     <Name>Soneta Addon Project (Soneta.Sdk)</Name>
-    <Description>Projekt startowy przeznaczony dla developer'ów piszących dodatki do produktów firmy Soneta.</Description>
+    <Description>Projekt startowy przeznaczony dla developer'ów piszących dodatki do produktów firmy Soneta. Samodzielnie utworzony projekt do poprawnego działania wymaga plików konfiguracyjnych zawartych w szablonie 'Soneta Addon Config'.</Description>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>
     </ProjectSubType>

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/SonetaAddon.Tests.vstemplate
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/SonetaAddon.Tests.vstemplate
@@ -1,7 +1,7 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
     <Name>Soneta Addon Project Tests (Soneta.Sdk)</Name>
-    <Description>Projekt startowy przeznaczony dla developer'ów piszących testy dodatków do produktów firmy Soneta.</Description>
+    <Description>Projekt startowy przeznaczony dla developer'ów piszących testy dodatków do produktów firmy Soneta. Samodzielnie utworzony projekt do poprawnego działania wymaga plików konfiguracyjnych zawartych w szablonie 'Soneta Addon Config'.</Description>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>
     </ProjectSubType>

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/SonetaAddon.UI.vstemplate
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/SonetaAddon.UI.vstemplate
@@ -1,7 +1,7 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
     <Name>Soneta Addon Project UI (Soneta.Sdk)</Name>
-    <Description>Projekt startowy przeznaczony dla developer'ów piszących warstwę interfejsu użytkownika dodatków do produktów firmy Soneta.</Description>
+    <Description>Projekt startowy przeznaczony dla developer'ów piszących warstwę interfejsu użytkownika dodatków do produktów firmy Soneta. Samodzielnie utworzony projekt do poprawnego działania wymaga plików konfiguracyjnych zawartych w szablonie 'Soneta Addon Config'.</Description>
     <ProjectType>CSharp</ProjectType>
     <ProjectSubType>
     </ProjectSubType>

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/project.template.config/template.json
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/project.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Soneta",
   "classifications": [ "Soneta", "Addon", "Project" ],
   "name": "Soneta Addon Project",
-  "description": "Projekt startowy przeznaczony dla developer'ów piszących dodatki do produktów firmy Soneta.",
+  "description": "Projekt startowy przeznaczony dla developer'ów piszących dodatki do produktów firmy Soneta. Samodzielnie utworzony projekt do poprawnego działania wymaga plików konfiguracyjnych zawartych w szablonie 'Soneta Addon Config'.",
   "groupIdentity": "Soneta.Addon.Project",
   "identity": "Soneta.Addon.Project",
   "shortName": "soneta-addon-project",

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/test.template.config/template.json
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/test.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Soneta",
   "classifications": [ "Soneta", "Addon", "Project", "Tests", "NUnit" ],
   "name": "Soneta Addon Project Tests",
-  "description": "Projekt startowy przeznaczony dla developer'ów piszących testy dodatków do produktów firmy Soneta.",
+  "description": "Projekt startowy przeznaczony dla developer'ów piszących testy dodatków do produktów firmy Soneta. Samodzielnie utworzony projekt do poprawnego działania wymaga plików konfiguracyjnych zawartych w szablonie 'Soneta Addon Config'.",
   "groupIdentity": "Soneta.Addon.Project.Tests",
   "identity": "Soneta.Addon.Project.Tests",
   "shortName": "soneta-addon-tests",

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/ui.template.config/template.json
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/ui.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Soneta",
   "classifications": [ "Soneta", "Addon", "Project", "UI" ],
   "name": "Soneta Addon Project UI",
-  "description": "Projekt startowy przeznaczony dla developer'ów piszących warstwę interfejsu użytkownika dodatków do produktów firmy Soneta.",
+  "description": "Projekt startowy przeznaczony dla developer'ów piszących warstwę interfejsu użytkownika dodatków do produktów firmy Soneta. Samodzielnie utworzony projekt do poprawnego działania wymaga plików konfiguracyjnych zawartych w szablonie 'Soneta Addon Config'.",
   "groupIdentity": "Soneta.Addon.Project.UI",
   "identity": "Soneta.Addon.Project.UI",
   "shortName": "soneta-addon-ui",


### PR DESCRIPTION
Samodzielne utworzenie pojedynczego projektu z szablonu (Project, UI, Tests) spowoduje wystąpienie wyjątku. Te projekty wymagają plików konfiguracyjnych (global.json, Directory.Build.props). Aby działało to poprawnie, należy w pierwszej kolejności utworzyć te pliki za pomocą szablonu "Soneta Addon Config". 

Początkowo myślałem o jakimś komunikacie w stylu messagebox z informacją czego brakuje, ale jest to dość ciężkie do określenia. Sama obecność wymaganych plików nie gwarantuje, że zawierają to co trzeba, a nawet ich parsowanie w celu wyszukiwania pożądanej wartości nie koniecznie zagwarantuje nam, że wszystko będzie zgodne z wymaganymi plikami konfiguracyjnymi. Z tego powodu zdecydowałem się ograniczyć jedynie do umieszczenia stosownej informacji w opisie szablonu. Jeśli macie jakieś inne propozycje dajcie znać.