### PR TITLE
Poprawa błędów związanych z brakiem lub niepoprawnym generowaniem końcówek nazw (.UI, .Tests) folderów projektów

### DIFF
--- a/Soneta.Platform.Developer/ItemTemplateWizard/Wizards/SonetaAddonProjectTemplateWizard.cs
+++ b/Soneta.Platform.Developer/ItemTemplateWizard/Wizards/SonetaAddonProjectTemplateWizard.cs
@@ -11,10 +11,9 @@ namespace ItemTemplateWizard.Wizards
     {
         private DTE dte;
         private string solutionDir;
-        private string projectDir;
+        private string destinationDir;
         private string projectSuffix;
-        private bool configProject;
-        const string solutionItemsFolderName = "Solution Items";
+        private const string SolutionItemsFolderName = "Solution Items";
 
         public void BeforeOpeningFile(ProjectItem projectItem)
         {
@@ -22,28 +21,10 @@ namespace ItemTemplateWizard.Wizards
 
         public void ProjectFinishedGenerating(Project project)
         {
-            project.Name = Path.ChangeExtension(project.Name, projectSuffix);
-
-            if (configProject)
-            {
-                var solutionItemsFolder = dte.Solution.Projects.Cast<Project>().FirstOrDefault(x => x.Name.Equals(solutionItemsFolderName, System.StringComparison.OrdinalIgnoreCase));
-                solutionItemsFolder = solutionItemsFolder ?? ((Solution2)dte.Solution).AddSolutionFolder(solutionItemsFolderName);
-
-                foreach (ProjectItem item in project.ProjectItems)
-                {
-                    var sourcePath = Path.Combine(projectDir, item.Name);
-                    var targetPath = Path.Combine(solutionDir, item.Name);
-                    File.Move(sourcePath, targetPath);
-                    solutionItemsFolder.ProjectItems.AddFromFile(targetPath);
-                }
-
-                dte.Solution.Remove(project);
-
-                if (projectDir == solutionDir)
-                    File.Delete(project.FullName);
-                else
-                    Directory.Delete(projectDir, true);
-            }
+            if (projectSuffix == "Config")
+                ProcessConfigFiles(project);
+            else
+                EnsureSuffix(project);
         }
 
         public void ProjectItemFinishedGenerating(ProjectItem projectItem)
@@ -58,14 +39,74 @@ namespace ItemTemplateWizard.Wizards
         {
             dte = (DTE)automationObject;
             replacementsDictionary.TryGetValue("$solutiondirectory$", out solutionDir);
-            replacementsDictionary.TryGetValue("$destinationdirectory$", out projectDir);
+            replacementsDictionary.TryGetValue("$destinationdirectory$", out destinationDir);
             replacementsDictionary.TryGetValue("$projectsuffix$", out projectSuffix);
-            configProject = projectSuffix == "Config";
         }
 
         public bool ShouldAddProjectItem(string filePath)
         {
             return true;
-        } 
+        }
+
+        private void ProcessConfigFiles(Project project)
+        {
+            var solutionItemsFolder = GetProjects(SolutionItemsFolderName).FirstOrDefault() ?? ((Solution2)dte.Solution).AddSolutionFolder(SolutionItemsFolderName);
+
+            foreach (ProjectItem item in project.ProjectItems)
+            {
+                var sourcePath = Path.Combine(destinationDir, item.Name);
+                var targetPath = Path.Combine(solutionDir, item.Name);
+                File.Move(sourcePath, targetPath);
+                solutionItemsFolder.ProjectItems.AddFromFile(targetPath);
+            }
+
+            dte.Solution.Remove(project);
+
+            if (destinationDir == solutionDir)
+                File.Delete(project.FullName);
+            else
+                Directory.Delete(destinationDir, true);
+        }
+
+        private void EnsureSuffix(Project project)
+        {
+            if (string.IsNullOrEmpty(projectSuffix))
+                return;
+
+            project.Name = GetProjectNameWithSuffix(project);
+            EnsureProjectDirectoryNameWithSuffix(project);
+        }
+
+        private string GetProjectNameWithSuffix(Project project)
+        {
+            var sourceExtension = Path.GetExtension(project.Name);
+            var targetExtension = $".{projectSuffix}";
+
+            if (sourceExtension.Equals(targetExtension, System.StringComparison.InvariantCultureIgnoreCase))
+                return Path.ChangeExtension(project.Name, targetExtension);
+            else
+                return project.Name + targetExtension;
+        }
+
+        private void EnsureProjectDirectoryNameWithSuffix(Project project)
+        {
+            if (destinationDir == solutionDir || project.Name == Path.GetFileName(destinationDir))
+                return;
+
+            dte.Solution.Remove(project);
+            var targetDir = Path.Combine(solutionDir, project.Name);
+            Directory.Move(destinationDir, targetDir);
+            dte.Solution.AddFromFile(Path.Combine(targetDir, Path.GetFileName(project.FullName)));
+        }
+
+        private IEnumerable<Project> GetProjects(string name = null)
+        {
+            var projects = dte.Solution.Projects.Cast<Project>();
+
+            if (!string.IsNullOrEmpty(name))
+                projects = projects.Where(x => x.Name.Equals(name, System.StringComparison.OrdinalIgnoreCase));
+
+            return projects;
+        }
     }
 }

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/Directory.Build.props
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SonetaPackageVersion>1905.0.1</SonetaPackageVersion>
+    <SonetaPackageVersion>1907.0.0</SonetaPackageVersion>
     <SonetaTargetFramework>net46</SonetaTargetFramework>
   </PropertyGroup>
 </Project>

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/global.json
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Soneta.Sdk": "1.0.0"
+    "Soneta.Sdk": "1.0.1"
   }
 }

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/project.template.config/template.json
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/project.template.config/template.json
@@ -12,13 +12,13 @@
     "type": "project"
   },
   "sourceName": "SonetaAddonProject",
-  "preferNameDirectory": true,
   "defaultName": "SonetaAddonProject",
   "sources": [
     {
       "include": [
         "SonetaAddonProject.csproj"
-      ]
+      ],
+      "target": ".\\SonetaAddonProject"
     }
   ]
 }

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/test.template.config/template.json
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/test.template.config/template.json
@@ -12,13 +12,13 @@
     "type": "project"
   },
   "sourceName": "SonetaAddonProject",
-  "preferNameDirectory": true,
   "defaultName": "SonetaAddonProject",
   "sources": [
     {
       "include": [
         "SonetaAddonProject.csproj"
       ],
+      "target": ".\\SonetaAddonProject.Tests",
       "rename": {
         "SonetaAddonProject": "SonetaAddonProject.Tests"
       }

--- a/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/ui.template.config/template.json
+++ b/Soneta.Platform.Developer/SonetaAddon/SonetaAddonProject/ui.template.config/template.json
@@ -12,7 +12,6 @@
     "type": "project"
   },
   "sourceName": "SonetaAddonProject",
-  "preferNameDirectory": true,
   "defaultName": "SonetaAddonProject",
   "sources": [
     {
@@ -20,6 +19,7 @@
         "SonetaAddonProject.csproj",
         "EnsureSonetaTypesReferenceClass.cs"
       ],
+      "target": ".\\SonetaAddonProject.UI",
       "rename": {
         "SonetaAddonProject": "SonetaAddonProject.UI"
       }


### PR DESCRIPTION
PR rozwiązuje poniższe problemy:

- w przypadku tworzenia projektu z szablonu, nadanie nazwy zawierającej kropkę, np. "Soneta.Addon" powoduje niepoprawne dodanie suffix'u do nazwy projektu (.UI, .Tests) co może powodować dalsze problemy (wyjątki),
- dodając pojedynczy projekt (zarówno VS jak .net core) suffix: UI lub Tests jest dodawany tylko do projektu, ale już nie dla folderu zawierającego projekt,
- nieaktualna wersja Soneta.Sdk i SonetaPackageVersion.