### PR TITLE
Zmiana folderu dla elementu <import />

### DIFF
--- a/Soneta.Platform.Developer/BusinessXml105ItemTemplate/file.business.xml
+++ b/Soneta.Platform.Developer/BusinessXml105ItemTemplate/file.business.xml
@@ -14,9 +14,11 @@
   versionNumber - atrybut versionNumber określa numer wersji o danej nazwie. Liczba ta powinna być zwiększana zawsze, gdy dokonujemy zmian w module, który został opublikowany publicznie i konieczna będzie konwersja. Taka sama wartość atrybutu versionName może być przypisany wielu modułom. Ale wystarczy, że tylko jeden z nich będzie określał numer wersji atrybutem versionNumber. 
   -->
 
-  <import>Generator</import>
+  <import>..</import>
   <!-- 
-  Ten atrybut deklaruje folder, w którym będą poszukiwane pozostałe pliki business.xml. Wczytywane są wszystkie  pliki ze wskazanego foldera oraz z polderów podrzędnych. W tym przypadku pozostałe deklaracje business.xml znajdują się w podkatalogu Generator.
+  Ten atrybut deklaruje folder, w którym będą poszukiwane pozostałe pliki business.xml.
+  Wczytywane są wszystkie pliki ze wskazanego foldera oraz folderów podrzędnych.
+  W tym przypadku uwzględnione zostaną wszystkie deklaracje business.xml w folderze nadrzędnym i jego podrzędnych.
   -->
 
   <!-- 

--- a/Soneta.Platform.Developer/BusinessXml105ItemTemplate/file.business.xml
+++ b/Soneta.Platform.Developer/BusinessXml105ItemTemplate/file.business.xml
@@ -14,7 +14,7 @@
   versionNumber - atrybut versionNumber określa numer wersji o danej nazwie. Liczba ta powinna być zwiększana zawsze, gdy dokonujemy zmian w module, który został opublikowany publicznie i konieczna będzie konwersja. Taka sama wartość atrybutu versionName może być przypisany wielu modułom. Ale wystarczy, że tylko jeden z nich będzie określał numer wersji atrybutem versionNumber. 
   -->
 
-  <import>..</import>
+  <import>../..</import>
   <!-- 
   Ten atrybut deklaruje folder, w którym będą poszukiwane pozostałe pliki business.xml.
   Wczytywane są wszystkie pliki ze wskazanego foldera oraz folderów podrzędnych.


### PR DESCRIPTION
Folder Generator jest adekwatny dla tych dodatków, które kopiują produkcyjne pliki business.xml.
Ta praktyka nie ma sensu od czasu kiedy pliki business.xml sa dystrybuowane z paczkami nuget
i SDK potrafi do nich referować bez potrzeby ich kopiowania.

Aktualnie zdecydowanie lepszym rozwiązaniem jest rekursywny import wszystkich pozostałych
business.xml z folderu nadrzędnego.